### PR TITLE
Fix typo in experience description

### DIFF
--- a/constants/data.ts
+++ b/constants/data.ts
@@ -177,7 +177,7 @@ const userData: UserData = {
             company: "Capgemini",
             year: "August 2017",
             companyLink: "https://capgemini.com",
-            desc: "Various consulting positions in open banking, digital transaformation, fintech, and blockchain.",
+            desc: "Various consulting positions in open banking, digital transformation, fintech, and blockchain.",
         },
     ],
     resumeUrl:


### PR DESCRIPTION
## Summary
- fix typo in Senior Consultant experience description

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a22ca34558832b80bf390980228fb3