### PR TITLE
Fix headshot path for GitHub Pages

### DIFF
--- a/components/OptimizedImage.tsx
+++ b/components/OptimizedImage.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useRef, useEffect } from 'react';
+import { useRouter } from 'next/router';
 import ImageSkeleton from './ImageSkeleton';
 
 interface OptimizedImageProps {
@@ -27,6 +28,7 @@ const OptimizedImage: React.FC<OptimizedImageProps> = ({
     const [isLoaded, setIsLoaded] = useState(false);
     const [hasError, setHasError] = useState(false);
     const imgRef = useRef<HTMLImageElement>(null);
+    const { basePath } = useRouter();
 
     useEffect(() => {
         // For priority images, start loading immediately
@@ -57,6 +59,13 @@ const OptimizedImage: React.FC<OptimizedImageProps> = ({
         return () => observer.disconnect();
     }, [priority]);
 
+    // Handle images that may already be loaded (e.g., from cache or preload)
+    useEffect(() => {
+        if (imgRef.current?.complete) {
+            setIsLoaded(true);
+        }
+    }, [src]);
+
     const handleLoad = () => {
         setIsLoaded(true);
         setHasError(false);
@@ -73,7 +82,7 @@ const OptimizedImage: React.FC<OptimizedImageProps> = ({
             <div className={`relative ${className}`} style={style}>
                 <img
                     ref={imgRef}
-                    src={src}
+                    src={src.startsWith('http') ? src : `${basePath}${src}`}
                     alt={alt}
                     className={`transition-opacity duration-300 ${isLoaded ? 'opacity-100' : 'opacity-0'
                         } ${className}`}
@@ -98,7 +107,7 @@ const OptimizedImage: React.FC<OptimizedImageProps> = ({
         <div className="relative">
             <img
                 ref={imgRef}
-                src={src}
+                src={src.startsWith('http') ? src : `${basePath}${src}`}
                 alt={alt}
                 width={width}
                 height={height}

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -2,12 +2,16 @@ import "../styles/globals.css";
 import { ThemeProvider } from "next-themes";
 import type { AppProps } from 'next/app';
 import { useEffect } from 'react';
+import { useRouter } from 'next/router';
 import { preloadCriticalImages, optimizeImageLoading } from '../utils/imageOptimization';
 
 function MyApp({ Component, pageProps }: AppProps) {
+    const router = useRouter();
+
     useEffect(() => {
         // Preload critical images for better performance
-        preloadCriticalImages(optimizeImageLoading.priority);
+        const prioritized = optimizeImageLoading.priority.map(url => `${router.basePath}${url}`);
+        preloadCriticalImages(prioritized);
 
         // Add performance monitoring
         if (typeof window !== 'undefined' && 'performance' in window) {
@@ -28,7 +32,7 @@ function MyApp({ Component, pageProps }: AppProps) {
 
             return () => observer.disconnect();
         }
-    }, []);
+    }, [router.basePath]);
 
     return (
         <ThemeProvider defaultTheme="dark" attribute="class">


### PR DESCRIPTION
## Summary
- prefix image URLs with `basePath` so static assets like the headshot resolve on GitHub Pages
- preload critical images using `basePath`
- mark preloaded images as loaded so the hero headshot fades in correctly

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a2333f4f10832b9651f7c9799e074f