### PR TITLE
Add certifications section to portfolio site

### DIFF
--- a/components/AboutMe.tsx
+++ b/components/AboutMe.tsx
@@ -123,6 +123,17 @@ const AboutMe: React.FC = () => {
                                 ))}
                             </ul>
                         </div>
+
+                        <h2 className="text-xl font-semibold text-gray-700 mt-8 dark:text-gray-200">
+                            Certifications
+                        </h2>
+                        <div className="text-lg text-gray-500 mt-4 dark:text-gray-300" style={{ paddingLeft: "1rem" }}>
+                            {userData.about.certifications?.map((cert, idx) => (
+                                <p key={idx} className="text-xl text-gray-700 mb-4 dark:text-gray-300 ">
+                                    {cert}
+                                </p>
+                            ))}
+                        </div>
                     </div>
                 </div>
             </div>

--- a/constants/data.ts
+++ b/constants/data.ts
@@ -8,6 +8,7 @@ interface About {
     title: string;
     description: string[];
     publicSpeaking: [string, string][];
+    certifications: string[];
 }
 
 interface Experience {
@@ -134,6 +135,9 @@ const userData: UserData = {
             [`Taking Faster Payments to the Bank - or CU`, `Glen Sarvady's BIGcast (podcast), May 2023`],
             [`Pay by Bank Powered by Real-Time Payments`, `Nacha's Smarter Faster Payments 2023, April 2023`],
             [`Industry Collaboration on DDA Payment Tokens in Support of a Safer Data Sharing & Payments Ecosystem`, `Financial Data Exchange Global Summit, April 2023`]
+        ],
+        certifications: [
+            "I am a Certified Digital Product Manager, credentialed by the Association of International Product Marketing and Management (AIPMM). This certification, issued in September 2023 (Credential ID: 82693844), validates my expertise in driving product strategy, lifecycle management, and innovation in digital products."
         ]
     },
     experience: [


### PR DESCRIPTION
## Summary
- add `certifications` field to user data model and populate with AIPMM credential
- render new Certifications section on home page after Public Speaking

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a23cd3e0bc832b854917a1ebad43cf