### PR TITLE
Expose GA measurement ID in deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,6 +26,7 @@ jobs:
       - run: npm run build
         env:
           BASE_PATH: /${{ github.event.repository.name }}
+          NEXT_PUBLIC_GA_MEASUREMENT_ID: ${{ vars.NEXT_PUBLIC_GA_MEASUREMENT_ID }}
       - uses: actions/upload-pages-artifact@v3
         with:
           path: ./out


### PR DESCRIPTION
## Summary
- pass NEXT_PUBLIC_GA_MEASUREMENT_ID env var to Next.js build

## Testing
- `npm test` (fails: Missing script)
- `CI=1 NEXT_PUBLIC_GA_MEASUREMENT_ID=G-XYZ npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a2497c3d18832b841416700371fc74