### PR TITLE
Add tests for image optimization utilities

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "scripts": {
     "dev": "next dev",
     "build": "next build",
-    "start": "next start"
+    "start": "next start",
+    "test": "tsc utils/imageOptimization.ts utils/imageOptimization.test.ts --module commonjs --target es2019 --outDir build --noEmit false && node --test build/imageOptimization.test.js && rm -rf build"
   },
   "dependencies": {
     "@next/third-parties": "^15.1.5",

--- a/utils/imageOptimization.test.ts
+++ b/utils/imageOptimization.test.ts
@@ -1,0 +1,21 @@
+import { test } from 'node:test';
+import * as assert from 'node:assert/strict';
+import { generateResponsiveImageUrl, getImageDimensions, createImagePlaceholder } from './imageOptimization';
+
+test('generateResponsiveImageUrl returns base URL', () => {
+  const base = 'https://example.com/image.jpg';
+  const result = generateResponsiveImageUrl(base, 800);
+  assert.equal(result, base);
+});
+
+test('getImageDimensions computes height from aspect ratio', () => {
+  const dims = getImageDimensions(2, 400);
+  assert.deepEqual(dims, { width: 400, height: 200 });
+});
+
+test('createImagePlaceholder encodes width, height, and color', () => {
+  const placeholder = createImagePlaceholder(100, 50, '#fff');
+  assert.match(placeholder, /width='100'/);
+  assert.match(placeholder, /height='50'/);
+  assert.match(placeholder, /fill='#fff'/);
+});


### PR DESCRIPTION
## Summary
- add npm test script compiling TypeScript utilities and running Node's test runner
- cover image optimization helpers with simple unit tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a249ea221c832baa67864c17873c6c