### PR TITLE
feat: declare english language for pages

### DIFF
--- a/components/ContainerBlock.tsx
+++ b/components/ContainerBlock.tsx
@@ -39,7 +39,6 @@ const ContainerBlock: React.FC<ContainerBlockProps> = ({ children, customMeta = 
                 <meta name="keywords" content="Florian Wahl, Product Leader, Product Strategy, Fintech, Digital Transformation, Akoya, Open Finance, Payments, API Development" />
                 <meta name="author" content="Florian Wahl" />
                 <meta name="news_keywords" content="Florian Wahl, Fintech, Product Strategy" />
-                <meta name="language" content="English" />
                 <meta name="revisit-after" content="7 days" />
                 <meta name="rating" content="General" />
                 <meta name="copyright" content="Florian Wahl" />

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -16,6 +16,10 @@ function MyApp({ Component, pageProps }: AppProps) {
     const gaId = process.env.NEXT_PUBLIC_GA_MEASUREMENT_ID;
 
     useEffect(() => {
+        document.documentElement.lang = "en";
+    }, []);
+
+    useEffect(() => {
         // Preload critical images for better performance
         const prioritized = optimizeImageLoading.priority.map(url => `${router.basePath}${url}`);
         preloadCriticalImages(prioritized);


### PR DESCRIPTION
## Summary
- remove redundant meta language declaration
- declare english language via existing `_app.tsx`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a33e9b7ee4832b9038926ad4e383b8