### PR TITLE
refactor: use OptimizedImage in FeaturedArticles

### DIFF
--- a/components/FeaturedArticles.tsx
+++ b/components/FeaturedArticles.tsx
@@ -42,10 +42,11 @@ const FeaturedArticles: React.FC = () => {
                     >
                         <div className="relative overflow-hidden">
                             <div className="relative w-full" style={{ aspectRatio: '16/9' }}>
-                                <img
+                                <OptimizedImage
                                     src="https://miro.medium.com/v2/resize:fit:1400/format:webp/1*ywYLQMzS1NLVWYHB3B7sZA.jpeg"
                                     alt="A Framework for Product Strategy - Product management framework illustration"
-                                    className="absolute inset-0 w-full h-full transform hover:scale-125 transition duration-2000 ease-out object-cover"
+                                    className="w-full h-full transform hover:scale-125 transition duration-2000 ease-out object-cover"
+                                    fill
                                 />
                             </div>
                             <h2 className="absolute top-4 md:top-10 left-4 md:left-10 text-gray-50 font-bold text-lg md:text-xl bg-red-500 rounded-md px-2 py-1 shadow-md">
@@ -60,10 +61,11 @@ const FeaturedArticles: React.FC = () => {
                     >
                         <div className="relative overflow-hidden">
                             <div className="relative w-full" style={{ aspectRatio: '16/9' }}>
-                                <img
+                                <OptimizedImage
                                     src="https://akoya.com/hubfs/Blog%20posts%20-%20SVGs/Instant%20ACH%20verification%20and%20meeting%20consumer%20expectations%20-%20Blog%20post.svg"
                                     alt="Akoya Blog Series - Financial technology and open banking articles"
-                                    className="absolute inset-0 w-full h-full transform hover:scale-125 transition duration-2000 ease-out object-cover"
+                                    className="w-full h-full transform hover:scale-125 transition duration-2000 ease-out object-cover"
+                                    fill
                                 />
                             </div>
                             <h2 className="absolute top-4 md:top-10 left-4 md:left-10 text-gray-50 font-bold text-lg md:text-xl bg-red-500 rounded-md px-2 py-1 shadow-md">
@@ -78,10 +80,11 @@ const FeaturedArticles: React.FC = () => {
                     >
                         <div className="relative overflow-hidden">
                             <div className="relative w-full" style={{ aspectRatio: '16/9' }}>
-                                <img
+                                <OptimizedImage
                                     src="https://miro.medium.com/v2/resize:fit:1400/format:webp/1*yg7tmTyUqldSMY6ITNfsLQ.png"
                                     alt="A Process For Product Management - Product management workflow diagram"
-                                    className="absolute inset-0 w-full h-full transform hover:scale-125 transition duration-2000 ease-out object-cover"
+                                    className="w-full h-full transform hover:scale-125 transition duration-2000 ease-out object-cover"
+                                    fill
                                 />
                             </div>
                             <h2 className="absolute top-4 md:top-10 left-4 md:left-10 text-gray-50 font-bold text-lg md:text-xl bg-red-500 rounded-md px-2 py-1 shadow-md max-w-[calc(100%-2rem)] md:max-w-60">
@@ -95,4 +98,4 @@ const FeaturedArticles: React.FC = () => {
     );
 };
 
-export default FeaturedArticles; 
+export default FeaturedArticles;


### PR DESCRIPTION
## Summary
- replace img elements with OptimizedImage in featured article cards
- drop image-specific classes now handled by OptimizedImage

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a519a4d4f8832bb0599d545c1395fb