### PR TITLE
refactor: use span for navbar username

### DIFF
--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -150,9 +150,9 @@ const Navbar: React.FC = () => {
                     {/* Logo and Name */}
                     <div className="flex flex-col">
                         <Link href="/">
-                            <h1 className="font-semibold text-xl md:text-4xl dark:text-gray-100">
+                            <span className="font-semibold text-xl md:text-4xl dark:text-gray-100">
                                 {userData.name}
-                            </h1>
+                            </span>
                             <p className="text-base font-light text-gray-500 dark:text-gray-300">
                                 {userData.designation}
                             </p>


### PR DESCRIPTION
## Summary
- replace `<h1>` with `<span>` for the name in Navbar

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a51aeb1e0c832b9310c2f382f254da