### PR TITLE
Revert navbar "Library" navigation back to "Articles"

### DIFF
--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -107,15 +107,15 @@ const Navbar: React.FC = () => {
                     {/* Desktop Navigation */}
                     <div className="space-x-4 hidden md:flex items-center">
                         <Link
-                            href="/library"
-                            onClick={() => event('nav_click', { destination: 'library' })}
+                            href="/articles"
+                            onClick={() => event('nav_click', { destination: 'articles' })}
                             className={`px-4 py-2 font-mono text-sm font-bold transition-colors duration-200 whitespace-nowrap ${
-                                router.asPath.startsWith("/library")
+                                router.asPath.startsWith("/articles")
                                     ? "bg-yellow-500 dark:bg-yellow-400 text-black pixel-border"
                                     : "text-black dark:text-white hover:bg-gray-200 dark:hover:bg-gray-800 pixel-border border-black dark:border-white"
                             }`}
                         >
-                            LIBRARY
+                            ARTICLES
                         </Link>
                         <Link
                             href="/experience"
@@ -231,18 +231,18 @@ const Navbar: React.FC = () => {
                                     HOME
                                 </Link>
                                 <Link
-                                    href="/library"
+                                    href="/articles"
                                     onClick={() => {
                                         setIsOpen(false);
-                                        event('nav_click', { destination: 'library' });
+                                        event('nav_click', { destination: 'articles' });
                                     }}
                                     className={`px-4 py-3 font-mono text-sm font-bold transition-colors ${
-                                        router.asPath.startsWith("/library")
+                                        router.asPath.startsWith("/articles")
                                             ? "bg-yellow-500 dark:bg-yellow-400 text-black pixel-border"
                                             : "text-black dark:text-white hover:bg-gray-200 dark:hover:bg-gray-800 pixel-border border-black dark:border-white"
                                     }`}
                                 >
-                                    LIBRARY
+                                    ARTICLES
                                 </Link>
                                 <Link
                                     href="/experience"


### PR DESCRIPTION
### Motivation
- The site navigation was changed back to use the existing Articles route and label instead of a Library route so the primary content link, active-route highlighting, and analytics align with the rest of the site.

### Description
- Updated `components/Navbar.tsx` to use `href="/articles"` for both desktop and mobile nav entries and to display the label `ARTICLES` instead of `LIBRARY`.
- Switched analytics destination values from `library` to `articles` and updated the active-route check to `router.asPath.startsWith("/articles")` for both desktop and mobile links.

### Testing
- Ran `npm test` and the test suite passed successfully.
- Attempted `npm run lint` but the project does not expose a `lint` script, so linting was not run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c871284074832b8348b9e41d4dbe7e)