### PR TITLE
Move Fintech Meetup talk from upcoming to conference talks

### DIFF
--- a/constants/data.ts
+++ b/constants/data.ts
@@ -100,6 +100,11 @@ const userData: UserData = {
     ],
     conferenceTalks: [
         {
+            title: "Can data aggregators power the next wave of smarter credit?",
+            venue: "Fintech Meetup",
+            date: "2026-04",
+        },
+        {
             title: "Open Banking in the US: Navigating Compliance Under the CFPB's 1033 Rule",
             venue: "OpenFinity EXPO",
             date: "2024-11",
@@ -136,13 +141,6 @@ const userData: UserData = {
         },
     ],
     upcomingEngagements: [
-        {
-            title: "Can data aggregators power the next wave of smarter credit?",
-            date: "2026-04-01",
-            conference: "Fintech Meetup",
-            location: "Las Vegas",
-            link: "https://fintechmeetup.com/agendas/2026-agenda/can-data-aggregators-power-the-next-wave-of-s",
-        },
         {
             title: "Beyond APIs: The Strategic Value of Data Out in Open Finance",
             date: "2026-04-27",


### PR DESCRIPTION
## Summary
Reorganized the "Can data aggregators power the next wave of smarter credit?" talk from the `upcomingEngagements` section to the `conferenceTalks` section, with simplified data structure.

## Key Changes
- Moved the Fintech Meetup talk entry from `upcomingEngagements` array to `conferenceTalks` array
- Simplified the data structure by removing unnecessary fields:
  - Removed `location` field ("Las Vegas")
  - Removed `link` field (conference URL)
  - Renamed `conference` to `venue` for consistency with other conference talks
  - Simplified `date` from full ISO format ("2026-04-01") to year-month format ("2026-04")

## Implementation Details
The talk is now stored in the `conferenceTalks` section with a consistent schema matching other conference entries, reducing data redundancy and improving maintainability.

https://claude.ai/code/session_01Bo8omEWDRKzN7WsnWYRejH