### PR TITLE
Migrate upcoming engagements to conference talks

### DIFF
--- a/constants/data.ts
+++ b/constants/data.ts
@@ -100,6 +100,16 @@ const userData: UserData = {
     ],
     conferenceTalks: [
         {
+            title: "Beyond APIs: The Strategic Value of Data Out in Open Finance",
+            venue: "Nacha Payments 2026",
+            date: "2026-04",
+        },
+        {
+            title: "How DDA Tokenization Protects FIs and Empowers Consumers in the Era of Open Banking",
+            venue: "Nacha Payments 2026",
+            date: "2026-04",
+        },
+        {
             title: "Can data aggregators power the next wave of smarter credit?",
             venue: "Fintech Meetup",
             date: "2026-04",
@@ -140,22 +150,7 @@ const userData: UserData = {
             date: "2023-04",
         },
     ],
-    upcomingEngagements: [
-        {
-            title: "Beyond APIs: The Strategic Value of Data Out in Open Finance",
-            date: "2026-04-27",
-            conference: "Nacha Payments 2026",
-            location: "San Diego",
-            link: "https://payments.nacha.org/session/beyond-apis-strategic-value-data-out-open-finance",
-        },
-        {
-            title: "How DDA Tokenization Protects FIs and Empowers Consumers in the Era of Open Banking",
-            date: "2026-04-28",
-            conference: "Nacha Payments 2026",
-            location: "San Diego",
-            link: "https://payments.nacha.org/session/how-dda-tokenization-protects-fis-and-empowers-consumers-era-open-banking",
-        },
-    ],
+    upcomingEngagements: [],
     experience: [
         {
             title: "Head of Product Strategy",


### PR DESCRIPTION
## Summary
Moved two upcoming Nacha Payments 2026 conference talks from the `upcomingEngagements` array to the `conferenceTalks` array, consolidating all past and upcoming speaking engagements in a single location.

## Key Changes
- Added two Nacha Payments 2026 talks to the `conferenceTalks` array:
  - "Beyond APIs: The Strategic Value of Data Out in Open Finance"
  - "How DDA Tokenization Protects FIs and Empowers Consumers in the Era of Open Banking"
- Cleared the `upcomingEngagements` array by removing the same two entries
- Simplified the data structure by removing detailed metadata (location, link) that was only in `upcomingEngagements`

## Implementation Details
The talks are now stored with a simplified schema (title, venue, date) consistent with other `conferenceTalks` entries, rather than the more detailed `upcomingEngagements` format. This consolidation makes the data structure more maintainable and treats all conference talks uniformly regardless of timing.

https://claude.ai/code/session_01KAqdUcCQLrt91FxhiNvixc